### PR TITLE
Add ByteDance Bagel model for image editing

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -549,8 +549,9 @@ class Admin {
 					'black-forest-labs/flux-schnell' => 'Flux Schnell',
 					'black-forest-labs/flux-pro'     => 'Flux Pro',
 					'recraft-ai/recraft-v3'          => 'Recraft v3',
-					'ideogram-ai/ideogram-v2a'       => 'Ideogram v2a',
-				],
+                                       'ideogram-ai/ideogram-v2a'       => 'Ideogram v2a',
+                                       'bytedance/bagel:7dd8def79e503990740db4704fa81af995d440fefe714958531d7044d2757c9c' => 'Bagel 7B',
+                               ],
 			];
 
 			$settings = get_option( 'superdraft_settings', [] );
@@ -579,8 +580,9 @@ class Admin {
 			$edit_models = [
 				''                                      => __( 'No image edits', 'superdraft' ),
 				'gemini-2.0-flash-exp-image-generation' => 'Gemini 2.0 Flash Experimental',
-				'gpt-image-1'                           => 'GPT Image 1',
-			];
+                                'gpt-image-1'                           => 'GPT Image 1',
+                                'bytedance/bagel:7dd8def79e503990740db4704fa81af995d440fefe714958531d7044d2757c9c' => 'Bagel 7B',
+                        ];
 
 			$settings = get_option( 'superdraft_settings', [] );
 			$selected = $settings['images']['image_edit_model'] ?? '';

--- a/includes/api/class-replicate-image-api.php
+++ b/includes/api/class-replicate-image-api.php
@@ -96,15 +96,19 @@ class Replicate_Image_API extends API {
 			);
 		}
 
-		$output = $data['output'] ?? '';
-		if ( empty( $output ) ) {
-			return new \WP_Error( 'api_error', __( 'Replicate API returned no output.', 'superdraft' ) );
-		}
+                $output = $data['output'] ?? '';
+                if ( empty( $output ) ) {
+                        return new \WP_Error( 'api_error', __( 'Replicate API returned no output.', 'superdraft' ) );
+                }
 
-		// Output can be string or array.
-		if ( is_array( $output ) ) {
-			$output = reset( $output );
-		}
+                // Output can be string or array/object.
+                if ( is_array( $output ) ) {
+                        if ( isset( $output['image'] ) ) {
+                                $output = $output['image'];
+                        } else {
+                                $output = reset( $output );
+                        }
+                }
 
 		$image_response = wp_remote_get( $output );
 		if ( is_wp_error( $image_response ) ) {

--- a/src/images.js
+++ b/src/images.js
@@ -91,7 +91,7 @@ import TurndownService from 'turndown';
                const editModel = window.superdraftSettings?.images?.image_edit_model || '';
 
                // Determine if the selected edit model supports editing
-               const modelSupportsEditing = editModel && ( editModel === 'gpt-image-1' || editModel.startsWith( 'gemini-' ) );
+               const modelSupportsEditing = editModel && ( editModel === 'gpt-image-1' || editModel.startsWith( 'gemini-' ) || editModel.startsWith( 'bytedance/bagel' ) );
 
 		const { postId, featuredImageId } = useSelect( state => ({
 			postId: select( 'core/editor' ).getEditedPostAttribute( 'id' ),


### PR DESCRIPTION
## Summary
- enable Replicate Bagel model for image generation and editing
- allow Bagel edits via base64 image input
- handle Replicate output object format
- expose Bagel in settings dropdowns
- detect Bagel editing capability in editor JS

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685217117854832981fab92d5e5e155e